### PR TITLE
fixed directory for save file of devices to fake

### DIFF
--- a/mosquitto.md
+++ b/mosquitto.md
@@ -62,3 +62,20 @@ Subscribe
 ```
 mosquitto_sub -h [HOSTNAME] -t test/#
 ```
+
+
+## Running the faker container
+
+With the current dir being the volume dir for sensors.list
+
+```
+podman run -p 1883 -v ./:/app/data faker:latest -d
+```
+
+## Adding devices to the faker
+
+UUID must be valid and in quotes
+
+```
+mosquitto_pub -h otp1.0x6a4b.dev -m "VALID_UUID" -t sensor/data/add_device -i client_name -u test_user -P test1234 -d
+```

--- a/mqtt/client/Dockerfile
+++ b/mqtt/client/Dockerfile
@@ -1,4 +1,8 @@
 FROM openjdk:21
+
+WORKDIR /app
+
 ARG JAR_FILE=target/Faker.jar
 COPY ${JAR_FILE} app.jar
-ENTRYPOINT ["java","-jar","/app.jar"]
+
+ENTRYPOINT ["java","-jar","app.jar"]

--- a/mqtt/client/src/main/java/dev/_x6a4b/otp1/Sensors.java
+++ b/mqtt/client/src/main/java/dev/_x6a4b/otp1/Sensors.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 public class Sensors {
     private List<String> uuids = new ArrayList<>();
-    private final String filename = "sensors.list";
+    private final String filename = "data/sensors.list";
 
     public Sensors(){
         loadSensors();


### PR DESCRIPTION
the directory must be different form .jar location for volume to work

this is needed to retain sensors-list configuration file after rebuilds and deploys of the faker